### PR TITLE
Fix 404 broken link

### DIFF
--- a/docs/docs/03_content/06_pagination.md
+++ b/docs/docs/03_content/06_pagination.md
@@ -65,6 +65,6 @@ name is just a number!
 
 [tpl]: {{docurl('content/templating')}}
 [tpldata]: {{docurl('reference/templating-data')}}
-[dcm]: {{docurl('content-model/default-content-model')}}
+[dcm]: {{docurl('content-model/default-model')}}
 [fil]: {{docurl('content/filtering')}}
 


### PR DESCRIPTION
Hi @ludovicchabant! I'm migrating an old website built using PHP Piecrust, and while reading the docs hit a 404. Checking other pages, I believe this is the correct location, but feel free to fix it accordingly if otherwise.

Thanks! The Python version looks even better than the PHP one. Kudos.