### PR TITLE
Add space before link

### DIFF
--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -152,8 +152,7 @@ your web server. When that's done, you should be able to see the exact same
 website being served from there.
 
 
-That's it! This is an extremely quick tour of PieCrust. Read the
-[documentation][doc] to learn more.
+That's it! This is an extremely quick tour of PieCrust. Read the [documentation][doc] to learn more.
 
 
 [1]: https://www.python.org/downloads/


### PR DESCRIPTION
I always thought that adding a break line, it would automatically add a space. But from the current documentation page https://bolt80.com/piecrust/en/latest/getting-started/, looks like if the next line starts with a link, it gets truncated.
