### PR TITLE
Allow page source to post-process page config at the end of page loading

### DIFF
--- a/piecrust/page.py
+++ b/piecrust/page.py
@@ -139,6 +139,7 @@ class Page(object):
         if was_cache_valid:
             self._flags |= FLAG_RAW_CACHE_VALID
 
+        self.source.finalizeConfig(self)
 
 def _parse_config_date(page_date):
     if page_date is None:

--- a/piecrust/sources/base.py
+++ b/piecrust/sources/base.py
@@ -135,4 +135,7 @@ class PageSource(object):
             self._provider_type = cls
 
         return self._provider_type(self, page, override)
+    
+    def finalizeConfig(self, page):
+        pass
 


### PR DESCRIPTION
I have a source plugin that needs to transform page metadata (stored in YAML frontmatter) before rendering.

I could have the plugin load the frontmatter, make the necessary changes, and put the modified data in the PageFactory, but that seems like a hack, because then the plugin will be loading metadata, and later the Page class itself will be loading the same metadata, and they'll be getting into a fight over who wins. 

Instead, what I am doing is giving a source plugin the ability to edit page config data after it's been loaded but before any further processing (routing, rendering, etc) occurs, by means of a finalizeConfig call in the source plugin API.