### PR TITLE
Allow page generators to have an associated data provider

### DIFF
--- a/piecrust/app.py
+++ b/piecrust/app.py
@@ -200,6 +200,11 @@ class PieCrust(object):
             tgts.append(tgt)
         return tgts
 
+    @cached_property
+    def dataProviderClasses(self):
+        return self.plugin_loader.getDataProviders()
+        
+
     def getSource(self, source_name):
         for source in self.sources:
             if source.name == source_name:
@@ -235,6 +240,14 @@ class PieCrust(object):
             if pub.target == target_name:
                 return pub
         return None
+        
+    def getDataProviderClass(cls, provider_type):
+        for prov in cls.dataProviderClasses:
+            if prov.PROVIDER_NAME == provider_type:
+                return prov
+        raise ConfigurationError(
+                "Unknown data provider type: %s" % provider_type)
+    
 
     def _get_dir(self, default_rel_dir):
         abs_dir = os.path.join(self.root_dir, default_rel_dir)

--- a/piecrust/data/providersdata.py
+++ b/piecrust/data/providersdata.py
@@ -27,13 +27,14 @@ class DataProvidersData(collections.abc.Mapping):
             return
 
         self._dict = {}
-        for source in self._page.app.sources:
-            endpoint_bits = re_endpoint_sep.split(source.data_endpoint)
-            endpoint = self._dict
-            for e in endpoint_bits[:-1]:
-                if e not in endpoint:
-                    endpoint[e] = {}
-                endpoint = endpoint[e]
-            override = endpoint.get(endpoint_bits[-1])
-            provider = source.buildDataProvider(self._page, override)
-            endpoint[endpoint_bits[-1]] = provider
+        for source in self._page.app.sources + self._page.app.generators:
+            if source.data_endpoint:
+                endpoint_bits = re_endpoint_sep.split(source.data_endpoint)
+                endpoint = self._dict
+                for e in endpoint_bits[:-1]:
+                    if e not in endpoint:
+                        endpoint[e] = {}
+                    endpoint = endpoint[e]
+                override = endpoint.get(endpoint_bits[-1])
+                provider = source.buildDataProvider(self._page, override)
+                endpoint[endpoint_bits[-1]] = provider

--- a/piecrust/generation/base.py
+++ b/piecrust/generation/base.py
@@ -124,6 +124,14 @@ class PageGenerator(object):
             raise ConfigurationError(
                     "Generator '%s' requires a listing page ref." % name)
         self.page_ref = PageRef(app, page_ref)
+        self.data_endpoint = config.get('data_endpoint')
+        self.data_type = config.get('data_type')
+
+        if self.data_endpoint and not self.data_type:
+            raise ConfigurationError(
+                    "Generator '%s' requires a data type because it has a data endpoint." % name)
+        
+        self._provider_type = None
 
     @cached_property
     def source(self):
@@ -146,3 +154,7 @@ class PageGenerator(object):
     def onRouteFunctionUsed(self, route, route_metadata):
         pass
 
+    def buildDataProvider(self, page, override):
+        if not self._provider_type:
+            self._provider_type = self.app.getDataProviderClass(self.data_type)
+        return self._provider_type(self, page, override)

--- a/piecrust/sources/base.py
+++ b/piecrust/sources/base.py
@@ -125,14 +125,7 @@ class PageSource(object):
         raise NotImplementedError()
 
     def buildDataProvider(self, page, override):
-        if self._provider_type is None:
-            cls = next((pt for pt in self.app.plugin_loader.getDataProviders()
-                        if pt.PROVIDER_NAME == self.data_type),
-                       None)
-            if cls is None:
-                raise ConfigurationError(
-                        "Unknown data provider type: %s" % self.data_type)
-            self._provider_type = cls
-
+        if not self._provider_type:
+            self._provider_type = self.app.getDataProviderClass(self.data_type)
         return self._provider_type(self, page, override)
 


### PR DESCRIPTION
Just as it makes sense for pages provided by a page source to be accessible from templates, pages constructed by a page generator should be exposed to templates