### PR TITLE
Allow page source to customize asset discovery

### DIFF
--- a/piecrust/baking/single.py
+++ b/piecrust/baking/single.py
@@ -166,7 +166,7 @@ class PageBaker(object):
                 logger.debug("Copying page assets to: %s" % out_assets_dir)
                 _ensure_dir_exists(out_assets_dir)
 
-                qualified_page.source.buildAssetor(qualified_page, sub_uri).copyAssets(qualified_page, out_assets_dir)
+                qualified_page.source.buildAssetor(qualified_page, sub_uri).copyAssets(out_assets_dir)
 
             # Figure out if we have more work.
             has_more_subs = False

--- a/piecrust/baking/single.py
+++ b/piecrust/baking/single.py
@@ -166,7 +166,7 @@ class PageBaker(object):
                 logger.debug("Copying page assets to: %s" % out_assets_dir)
                 _ensure_dir_exists(out_assets_dir)
 
-                qualified_path.source.buildPageAssetor().copyAssets(page, out_assets_dir)
+                qualified_page.source.buildPageAssetor(qualified_page, sub_uri).copyAssets(qualified_page, out_assets_dir)
 
             # Figure out if we have more work.
             has_more_subs = False

--- a/piecrust/baking/single.py
+++ b/piecrust/baking/single.py
@@ -1,6 +1,5 @@
 import os.path
 import queue
-import shutil
 import logging
 import threading
 import urllib.parse
@@ -167,14 +166,7 @@ class PageBaker(object):
                 logger.debug("Copying page assets to: %s" % out_assets_dir)
                 _ensure_dir_exists(out_assets_dir)
 
-                page_pathname, _ = os.path.splitext(qualified_page.path)
-                in_assets_dir = page_pathname + ASSET_DIR_SUFFIX
-                for fn in os.listdir(in_assets_dir):
-                    full_fn = os.path.join(in_assets_dir, fn)
-                    if os.path.isfile(full_fn):
-                        dest_ap = os.path.join(out_assets_dir, fn)
-                        logger.debug("  %s -> %s" % (full_fn, dest_ap))
-                        shutil.copy(full_fn, dest_ap)
+                qualified_path.source.buildPageAssetor().copyAssets(page, out_assets_dir)
 
             # Figure out if we have more work.
             has_more_subs = False

--- a/piecrust/baking/single.py
+++ b/piecrust/baking/single.py
@@ -166,7 +166,7 @@ class PageBaker(object):
                 logger.debug("Copying page assets to: %s" % out_assets_dir)
                 _ensure_dir_exists(out_assets_dir)
 
-                qualified_page.source.buildPageAssetor(qualified_page, sub_uri).copyAssets(qualified_page, out_assets_dir)
+                qualified_page.source.buildAssetor(qualified_page, sub_uri).copyAssets(qualified_page, out_assets_dir)
 
             # Figure out if we have more work.
             has_more_subs = False

--- a/piecrust/data/assetor.py
+++ b/piecrust/data/assetor.py
@@ -94,8 +94,8 @@ class Assetor(object):
         if cpi is not None:
             cpi.render_ctx.current_pass_info.used_assets = True
             
-    def copyAssets(self, page, dest_dir):
-        page_pathname, _ = os.path.splitext(page.path)
+    def copyAssets(self, dest_dir):
+        page_pathname, _ = os.path.splitext(self._page.path)
         in_assets_dir = page_pathname + ASSET_DIR_SUFFIX
         for fn in os.listdir(in_assets_dir):
             full_fn = os.path.join(in_assets_dir, fn)

--- a/piecrust/data/assetor.py
+++ b/piecrust/data/assetor.py
@@ -32,12 +32,7 @@ def build_base_url(app, uri, rel_assets_path):
     return base_url.rstrip('/') + '/'
 
 
-class Assetor(object):
-    debug_render_doc = """Helps render URLs to files in the current page's
-                          asset folder."""
-    debug_render = []
-    debug_render_dynamic = ['_debugRenderAssetNames']
-
+class AssetorBase(object):
     def __init__(self, page, uri):
         self._page = page
         self._uri = uri
@@ -69,8 +64,23 @@ class Assetor(object):
     def _cacheAssets(self):
         if self._cache is not None:
             return
+            
+        self._cache = dict(self.findAssets())
+        
+    def findAssets(self):
+        raise NotImplementedError()
 
-        self._cache = {}
+    def copyAssets(self, dest_dir):
+        raise NotImplementedError()
+
+class Assetor(AssetorBase):
+    debug_render_doc = """Helps render URLs to files in the current page's
+                          asset folder."""
+    debug_render = []
+    debug_render_dynamic = ['_debugRenderAssetNames']
+
+    def findAssets(self):
+        assets = {}
         name, ext = os.path.splitext(self._page.path)
         assets_dir = name + ASSET_DIR_SUFFIX
         if not os.path.isdir(assets_dir):
@@ -85,14 +95,16 @@ class Assetor(object):
                 continue
 
             name, ext = os.path.splitext(fn)
-            if name in self._cache:
+            if name in assets:
                 raise UnsupportedAssetsError(
                         "Multiple asset files are named '%s'." % name)
-            self._cache[name] = (base_url + fn, full_fn)
+            assets[name] = (base_url + fn, full_fn)
 
         cpi = self._page.app.env.exec_info_stack.current_page_info
         if cpi is not None:
             cpi.render_ctx.current_pass_info.used_assets = True
+        
+        return assets
             
     def copyAssets(self, dest_dir):
         page_pathname, _ = os.path.splitext(self._page.path)

--- a/piecrust/data/assetor.py
+++ b/piecrust/data/assetor.py
@@ -1,5 +1,6 @@
 import os
 import os.path
+import shutil
 import logging
 from piecrust import ASSET_DIR_SUFFIX
 from piecrust.uriutil import multi_replace
@@ -92,4 +93,13 @@ class Assetor(object):
         cpi = self._page.app.env.exec_info_stack.current_page_info
         if cpi is not None:
             cpi.render_ctx.current_pass_info.used_assets = True
-
+            
+    def copyAssets(self, page, dest_dir):
+        page_pathname, _ = os.path.splitext(page.path)
+        in_assets_dir = page_pathname + ASSET_DIR_SUFFIX
+        for fn in os.listdir(in_assets_dir):
+            full_fn = os.path.join(in_assets_dir, fn)
+            if os.path.isfile(full_fn):
+                dest_ap = os.path.join(dest_dir, fn)
+                logger.debug("  %s -> %s" % (full_fn, dest_ap))
+                shutil.copy(full_fn, dest_ap)

--- a/piecrust/data/builder.py
+++ b/piecrust/data/builder.py
@@ -39,7 +39,7 @@ def build_page_data(ctx):
     paginator = Paginator(page, pgn_source,
                           page_num=ctx.page_num,
                           pgn_filter=ctx.pagination_filter)
-    assetor = page.source.buildPageAssetor(page, first_uri)
+    assetor = page.source.buildAssetor(page, first_uri)
     linker = PageLinkerData(page.source, page.rel_path)
     data = {
             'piecrust': pc_data,

--- a/piecrust/data/builder.py
+++ b/piecrust/data/builder.py
@@ -1,6 +1,5 @@
 import logging
 from werkzeug.utils import cached_property
-from piecrust.data.assetor import Assetor
 from piecrust.data.base import MergedMapping
 from piecrust.data.linker import PageLinkerData
 from piecrust.data.pagedata import PageData
@@ -40,7 +39,7 @@ def build_page_data(ctx):
     paginator = Paginator(page, pgn_source,
                           page_num=ctx.page_num,
                           pgn_filter=ctx.pagination_filter)
-    assetor = Assetor(page, first_uri)
+    assetor = page.source.buildPageAssetor(page, first_uri)
     linker = PageLinkerData(page.source, page.rel_path)
     data = {
             'piecrust': pc_data,

--- a/piecrust/data/paginationdata.py
+++ b/piecrust/data/paginationdata.py
@@ -45,7 +45,7 @@ class PaginationData(LazyPageConfigData):
             self._setValue('date', page.datetime.strftime(date_format))
         self._setValue('mtime', page.path_mtime)
 
-        assetor = page.source.buildPageAssetor(page, page_url)
+        assetor = page.source.buildAssetor(page, page_url)
         self._setValue('assets', assetor)
 
         segment_names = page.config.get('segments')

--- a/piecrust/data/paginationdata.py
+++ b/piecrust/data/paginationdata.py
@@ -45,7 +45,7 @@ class PaginationData(LazyPageConfigData):
             self._setValue('date', page.datetime.strftime(date_format))
         self._setValue('mtime', page.path_mtime)
 
-        assetor = Assetor(page, page_url)
+        assetor = page.source.buildPageAssetor(page, page_url)
         self._setValue('assets', assetor)
 
         segment_names = page.config.get('segments')

--- a/piecrust/sources/base.py
+++ b/piecrust/sources/base.py
@@ -137,6 +137,6 @@ class PageSource(object):
 
         return self._provider_type(self, page, override)
 
-    def buildPageAssetor(self, page, uri):
+    def buildAssetor(self, page, uri):
         return Assetor(page, uri)
 

--- a/piecrust/sources/base.py
+++ b/piecrust/sources/base.py
@@ -3,6 +3,7 @@ import logging
 from werkzeug.utils import cached_property
 from piecrust.configuration import ConfigurationError
 from piecrust.page import Page
+from piecrust.data.assetor import Assetor
 
 
 REALM_USER = 0
@@ -135,4 +136,7 @@ class PageSource(object):
             self._provider_type = cls
 
         return self._provider_type(self, page, override)
+
+    def buildPageAssetor(self, page, uri):
+        return Assetor(page, uri)
 


### PR DESCRIPTION
My assets are not laid out in the foo-assets way that PieCrust likes, so I adde the ability for PageSource plugin to customize asset-finding.