### PR TITLE
Don’t swallow generic errors during baking

### DIFF
--- a/piecrust/baking/worker.py
+++ b/piecrust/baking/worker.py
@@ -231,7 +231,7 @@ class BakeJobHandler(JobHandler):
                     qp, previous_entry, dirty_source_names, gen_name)
             result['sub_entries'] = sub_entries
 
-        except BakingError as ex:
+        except Exception as ex:
             logger.debug("Got baking error. Sending it to master.")
             result['errors'] = _get_errors(ex)
             if self.ctx.app.debug:


### PR DESCRIPTION
I ran into a case where an error during baking would produce useless output (even in debug mode) because all exceptions other than BakingError were being swallowed by the worker without having their error information being sent to the master. Here's a fix.